### PR TITLE
feat: add `useForm` hook for advanced form management

### DIFF
--- a/app/__test__/useForm.test.ts
+++ b/app/__test__/useForm.test.ts
@@ -1,0 +1,239 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+import { useForm } from '../registry/composables/useForm'
+
+describe('useForm', () => {
+    const createStorageMock = () => {
+        let store: Record<string, string> = {}
+        return {
+            getItem: vi.fn((key: string) => store[key] || null),
+            setItem: vi.fn((key: string, value: string) => {
+                store[key] = value.toString()
+            }),
+            removeItem: vi.fn((key: string) => {
+                // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+                delete store[key]
+            }),
+            clear: vi.fn(() => {
+                store = {}
+            }),
+        }
+    }
+
+    const localStorageMock = createStorageMock()
+    const sessionStorageMock = createStorageMock()
+
+    beforeEach(() => {
+        vi.stubGlobal('localStorage', localStorageMock)
+        vi.stubGlobal('sessionStorage', sessionStorageMock)
+        localStorageMock.clear()
+        sessionStorageMock.clear()
+
+        // Mock location
+        Object.defineProperty(window, 'location', {
+            value: {
+                pathname: '/test',
+                search: '',
+            },
+            writable: true,
+        })
+    })
+
+    afterEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('should initialize with default values', () => {
+        const initialValues = {
+            name: 'John',
+            age: 30,
+            address: {
+                city: 'New York',
+                zip: '10001',
+            },
+        }
+
+        const { form } = useForm(initialValues, { autoPersist: false })
+
+        expect(form.name).toBe('John')
+        expect(form.age).toBe(30)
+        expect(form.address.city).toBe('New York')
+    })
+
+    it('should get field value using path', () => {
+        const initialValues = {
+            user: {
+                details: {
+                    name: 'Alice',
+                },
+            },
+        }
+
+        const { getFieldValue } = useForm(initialValues, { autoPersist: false })
+
+        expect(getFieldValue('user.details.name')).toBe('Alice')
+        expect(getFieldValue('user')).toEqual({ details: { name: 'Alice' } })
+    })
+
+    it('should set field value using path', () => {
+        const initialValues = {
+            user: {
+                name: 'Bob',
+                age: 25,
+            },
+        }
+
+        const { form, setFieldValue } = useForm(initialValues, { autoPersist: false })
+
+        setFieldValue('user.name', 'Charlie')
+        expect(form.user.name).toBe('Charlie')
+
+        setFieldValue('user.age', 26)
+        expect(form.user.age).toBe(26)
+    })
+
+    it('should set multiple fields values (patch)', () => {
+        const initialValues = {
+            name: 'David',
+            settings: {
+                theme: 'light',
+                notifications: true,
+            },
+        }
+
+        const { form, setFieldsValue } = useForm(initialValues, { autoPersist: false })
+
+        setFieldsValue({
+            name: 'Eve',
+            settings: {
+                theme: 'dark',
+            },
+        })
+
+        expect(form.name).toBe('Eve')
+        expect(form.settings.theme).toBe('dark')
+        expect(form.settings.notifications).toBe(true) // Should remain unchanged
+    })
+
+    it('should reset form to initial values', () => {
+        const initialValues = {
+            count: 0,
+        }
+
+        const { form, reset, setFieldValue } = useForm(initialValues, { autoPersist: false })
+
+        setFieldValue('count', 5)
+        expect(form.count).toBe(5)
+
+        reset()
+        expect(form.count).toBe(0)
+    })
+
+    it('should persist data to storage', () => {
+        const initialValues = { data: 'test' }
+        const { persist } = useForm(initialValues, { storage: 'local', secret: 'secret', autoPersist: false })
+
+        persist()
+
+        expect(localStorage.setItem).toHaveBeenCalled()
+        // Verify key is location based
+        const expectedKey = '/test'
+        expect(localStorage.setItem).toHaveBeenCalledWith(expectedKey, expect.any(String))
+    })
+
+    it('should restore data from storage on init', () => {
+        // Setup existing data in storage
+        const initialValues = { data: 'initial' }
+
+        // We need to use the internal encrypt logic or manually mock the stored value
+        // The hook uses: btoa(xor(JSON.stringify(obj), secret))
+        // Let's rely on the hook's own persist to set it up first, or manually mock
+
+        // Let's use a helper to encrypt compatible with the hook's logic if possible,
+        // or just use useForm to save it first in a separate instance.
+
+        // Create a temporary form to save data
+        const { persist: saveTemp, setFieldValue: setTemp } = useForm(initialValues, { storage: 'local', secret: 'key', autoPersist: false })
+        setTemp('data', 'restored')
+        saveTemp()
+
+        // Now create the actual form under test
+        const { form } = useForm(initialValues, { storage: 'local', secret: 'key', autoPersist: false })
+
+        expect(form.data).toBe('restored')
+    })
+
+    it('should clear cache', () => {
+        const initialValues = { data: 'test' }
+        const { persist, clearCache } = useForm(initialValues, { storage: 'session', autoPersist: false })
+
+        persist()
+        expect(sessionStorage.setItem).toHaveBeenCalled()
+
+        clearCache()
+        expect(sessionStorage.removeItem).toHaveBeenCalled()
+    })
+
+    it('should auto persist on unmount', async () => {
+        const TestComponent = defineComponent({
+            setup() {
+                const { form } = useForm({ value: 'initial' }, {
+                    storage: 'local',
+                    autoPersist: true,
+                    secret: 'secret',
+                })
+                return { form }
+            },
+            template: '<div></div>',
+        })
+
+        const wrapper = mount(TestComponent)
+        wrapper.vm.form.value = 'changed'
+
+        wrapper.unmount()
+
+        expect(localStorage.setItem).toHaveBeenCalled()
+
+        // Verify the stored value corresponds to 'changed'
+        // We can do this by trying to restore it
+        const { form: restoredForm } = useForm({ value: 'initial' }, {
+            storage: 'local',
+            secret: 'secret',
+            autoPersist: false,
+        })
+        expect(restoredForm.value).toBe('changed')
+    })
+
+    it('should not persist if cache is false', () => {
+        const { persist } = useForm({ val: 1 }, { cache: false, autoPersist: false })
+        persist()
+        expect(localStorage.setItem).not.toHaveBeenCalled()
+        expect(sessionStorage.setItem).not.toHaveBeenCalled()
+    })
+
+    it('should handle complex nested paths', () => {
+        const initialValues = {
+            a: {
+                b: {
+                    c: [1, 2, 3],
+                    d: {
+                        e: 'nested',
+                    },
+                },
+            },
+        }
+
+        const { form, setFieldValue, getFieldValue } = useForm(initialValues, { autoPersist: false })
+
+        // The type definition in useForm seems to handle array paths as dot notation?
+        // Let's check the implementation of setAtPath.
+        // It splits by '.', so 'a.b.c' accesses the array.
+        // However, standard JS array access via string key works for index.
+
+        // Let's try modifying an object nested deep
+        setFieldValue('a.b.d.e', 'changed')
+        expect(form.a.b.d.e).toBe('changed')
+        expect(getFieldValue('a.b.d.e')).toBe('changed')
+    })
+})

--- a/app/registry/composables/useForm.ts
+++ b/app/registry/composables/useForm.ts
@@ -1,0 +1,202 @@
+import { onUnmounted, reactive, toRaw } from 'vue'
+
+type Primitive = string | number | boolean | bigint | symbol | null | undefined
+type StorageType = 'session' | 'local'
+
+type Path<T> = T extends Primitive
+    ? never
+    : {
+            [K in keyof T & string]:
+                | K
+                | (T[K] extends Primitive ? K : `${K}.${Path<T[K]>}`)
+        }[keyof T & string]
+
+type PathValue<T, P extends Path<T>>
+    = P extends `${infer K}.${infer R}`
+        ? K extends keyof T
+            ? R extends Path<T[K]>
+                ? PathValue<T[K], R>
+                : never
+            : never
+        : P extends keyof T
+            ? T[P]
+            : never
+
+type DeepPartial<T> = {
+    [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K]
+}
+
+const deepClone = <T>(val: T): T =>
+    structuredClone
+        ? structuredClone(val)
+        : JSON.parse(JSON.stringify(val))
+
+const isObject = (val: unknown): val is Record<string, unknown> =>
+    typeof val === 'object' && val !== null
+
+const setAtPath = (
+    target: Record<string, unknown>,
+    path: string,
+    value: unknown,
+) => {
+    const keys = path.split('.')
+    const lastKey = keys.pop()!
+    let cur: Record<string, unknown> = target
+
+    for (const key of keys) {
+        cur[key] = isObject(cur[key]) ? cur[key] : {}
+        cur = cur[key] as Record<string, unknown>
+    }
+
+    cur[lastKey] = value
+}
+
+const getAtPath = (
+    target: Record<string, unknown>,
+    path: string,
+): unknown =>
+    path.split('.').reduce<unknown>((cur, key) => {
+        if (!isObject(cur)) return undefined
+        return cur[key]
+    }, target)
+
+const traverseLeaves = (
+    obj: unknown,
+    cb: (path: string, value: unknown) => void,
+    base = '',
+) => {
+    if (!isObject(obj)) return
+
+    for (const key of Object.keys(obj)) {
+        const path = base ? `${base}.${key}` : key
+        const val = obj[key]
+
+        if (isObject(val) && !Array.isArray(val))
+            traverseLeaves(val, cb, path)
+        else
+            cb(path, val)
+    }
+}
+
+const applyPatch = (
+    target: Record<string, unknown>,
+    values: unknown,
+) => {
+    traverseLeaves(values, (path, value) => {
+        setAtPath(target, path, value)
+    })
+}
+
+const replaceValues = (
+    target: Record<string, unknown>,
+    source: unknown,
+) => {
+    for (const key of Object.keys(target)) {
+        target[key] = undefined
+    }
+
+    if (isObject(source)) {
+        Object.assign(target, deepClone(source))
+    }
+}
+
+const xor = (str: string, key: string) =>
+    str
+        .split('')
+        .map((c, i) =>
+            String.fromCharCode(c.charCodeAt(0) ^ key.charCodeAt(i % key.length)),
+        )
+        .join('')
+
+const encrypt = (obj: unknown, secret: string) =>
+    btoa(xor(JSON.stringify(obj), secret))
+
+const decrypt = <T>(str: string, secret: string): T =>
+    JSON.parse(xor(atob(str), secret))
+
+const getStorage = (type: StorageType) =>
+    type === 'local' ? localStorage : sessionStorage
+
+const getCacheKey = () =>
+    location.pathname
+
+export function useForm<T extends Record<string, unknown>>(
+    initialValues: T,
+    options?: {
+        cache?: boolean
+        secret?: string
+        storage?: StorageType
+        autoPersist?: boolean
+    },
+) {
+    const form = reactive<T>(initialValues)
+    const snapshot = deepClone(initialValues)
+
+    const {
+        cache = true,
+        secret = 'AK78FB',
+        storage = 'session',
+        autoPersist = true,
+    } = options ?? {}
+
+    if (cache && secret) {
+        const store = getStorage(storage)
+        const cached = store.getItem(getCacheKey())
+
+        if (cached) {
+            try {
+                const data = decrypt<T>(cached, secret)
+                replaceValues(form, data)
+            }
+            catch {
+                store.removeItem(getCacheKey())
+            }
+        }
+    }
+
+    if (cache && autoPersist) {
+        onUnmounted(() => {
+            persist()
+        })
+    }
+
+    const reset = () => {
+        replaceValues(form, snapshot)
+    }
+
+    const setFieldValue = <P extends Path<T>>(
+        path: P,
+        value: PathValue<T, P>,
+    ) => {
+        setAtPath(form, path, value)
+    }
+
+    const getFieldValue = <P extends Path<T>>(path: P): PathValue<T, P> =>
+        getAtPath(toRaw(form), path) as PathValue<T, P>
+
+    const setFieldsValue = (values: DeepPartial<T>) => {
+        applyPatch(form, values)
+    }
+
+    const persist = () => {
+        if (!cache || !secret) return
+        getStorage(storage).setItem(
+            getCacheKey(),
+            encrypt(toRaw(form), secret),
+        )
+    }
+
+    const clearCache = () => {
+        getStorage(storage).removeItem(getCacheKey())
+    }
+
+    return {
+        form,
+        reset,
+        setFieldValue,
+        getFieldValue,
+        setFieldsValue,
+        persist,
+        clearCache,
+    }
+}

--- a/content/docs/2.composables/2.useForm.md
+++ b/content/docs/2.composables/2.useForm.md
@@ -1,0 +1,103 @@
+---
+title: useForm
+description: useForm is a powerful hook for form state management with built-in persistence, encryption, and nested path support.
+---
+
+`useForm` simplifies complex form handling by providing reactive state management, automatic persistence (localStorage/sessionStorage), data encryption, and type-safe nested field access.
+
+- **State Management**: Reactive form object with deep reactivity.
+- **Persistence**: Automatically save and restore form state from storage.
+- **Encryption**: Securely encrypt cached data to prevent plain text exposure.
+- **Nested Paths**: Access and update deeply nested fields using dot notation (e.g., `user.profile.name`).
+- **Reset**: Easily reset the form to its initial state.
+
+## Installation
+
+```bash
+npx shadcn-vue@latest add @shadcn-vue-hooks/useForm
+```
+
+## Usage
+
+### Basic Example
+
+```ts
+import { useForm } from '@/registry/composables/useForm'
+
+const { form, reset, persist } = useForm({
+  username: '',
+  email: '',
+  profile: {
+    age: 18
+  }
+})
+
+// Update form directly
+form.username = 'johndoe'
+
+// Or use methods
+reset() // Reset to initial values
+persist() // Manually save to storage
+```
+
+### With Persistence & Encryption
+
+Enable `cache` to automatically restore data on mount and save on unmount (if `autoPersist` is true).
+
+```ts
+const { form } = useForm(
+  { 
+    settings: { theme: 'dark', notifications: true } 
+  },
+  {
+    cache: true,
+    storage: 'local', // 'local' or 'session'
+    secret: 'my-secret-key', // Encryption key
+    autoPersist: true // Auto save on unmount
+  }
+)
+```
+
+### Accessing Nested Fields
+
+```ts
+const { setFieldValue, getFieldValue } = useForm({
+  user: {
+    details: {
+      address: {
+        city: 'New York'
+      }
+    }
+  }
+})
+
+// Type-safe path access
+setFieldValue('user.details.address.city', 'London')
+const city = getFieldValue('user.details.address.city')
+```
+
+## API
+
+### Parameters
+
+1. `initialValues`: Initial state object.
+2. `options` (optional):
+    - `cache`: `boolean` (default: `true`) - Enable storage persistence.
+    - `storage`: `'session' | 'local'` (default: `'session'`) - Storage type.
+    - `secret`: `string` - Key for encryption.
+    - `autoPersist`: `boolean` (default: `true`) - Save state on component unmount.
+
+### Return Values
+
+- `form`: The reactive form object.
+- `reset()`: Resets form to initial values.
+- `setFieldValue(path, value)`: Sets a specific field value.
+- `getFieldValue(path)`: Gets a specific field value.
+- `setFieldsValue(values)`: Updates multiple fields (deep merge).
+- `persist()`: Manually saves current state to storage.
+- `clearCache()`: Clears the stored data.
+
+## Source Code
+
+::ShowCode{file="composables/useForm.ts"}
+::


### PR DESCRIPTION
Introduce a `useForm` composable designed to simplify complex form state management, persistence, and data restoration.

**Features**

- Provides a fully reactive form object with strong TypeScript type inference.
- Supports reading and updating deeply nested fields via dot-notation paths (e.g. user.info.name).
- Built-in support for localStorage and sessionStorage, ensuring form data survives page refreshes.
- Supports automatic persistence on component unmount (Auto Persist) and automatic restoration during initialization.

**Options**

- cache (boolean, default: true) Enable or disable form state caching.
- storage ('session' | 'local', default: 'session') Specify the storage medium.
- secret (string) Encryption key used for encrypting and decrypting cached data.
- autoPersist (boolean, default: true) Automatically persist form state on component unmount (onUnmounted).

**Usage**

```js
const { form, reset, setFieldValue } = useForm(
  // 1. Initial values
  {
    username: '',
    profile: {
      age: 18,
      bio: ''
    }
  },
  // 2. Options
  {
    storage: 'local',
    autoPersist: true,
    secret: 'my-secret-key'
  }
)

// Update fields
form.username = 'shadcn-vue'
setFieldValue('profile.age', 20) // Type-safe path

// Reset to initial state
reset()
```